### PR TITLE
[PATCH] tpm: Add parentheses to TIS_HID_USR_IDX (safer coding style)

### DIFF
--- a/drivers/char/tpm/tpm_tis.c
+++ b/drivers/char/tpm/tpm_tis.c
@@ -226,7 +226,7 @@ static struct pnp_driver tis_pnp_driver = {
 	},
 };
 
-#define TIS_HID_USR_IDX sizeof(tpm_pnp_tbl)/sizeof(struct pnp_device_id) -2
+#define TIS_HID_USR_IDX (sizeof(tpm_pnp_tbl) / sizeof(struct pnp_device_id) - 2)
 module_param_string(hid, tpm_pnp_tbl[TIS_HID_USR_IDX].id,
 		    sizeof(tpm_pnp_tbl[TIS_HID_USR_IDX].id), 0444);
 MODULE_PARM_DESC(hid, "Set additional specific HID for this driver to probe");


### PR DESCRIPTION
It will be safer if we always parenthesize the body of such constant definitions.
By the way, it would be even safer than a "#define" if we use "const" to define constants:
```
const int TIS_HID_USR_IDX = (sizeof(tpm_pnp_tbl) / sizeof(struct pnp_device_id) - 2);
```